### PR TITLE
make `session` identifier sent by server available on the client

### DIFF
--- a/ddp-client.js
+++ b/ddp-client.js
@@ -36,6 +36,7 @@ class DDPClient {
         this.sock.onmessage = (wsMessage) => {
             const data = JSON.parse(wsMessage.data), {msg} = data
             if (msg === 'connected') {
+                this.sessionId = data.session
                 return d.resolve(data)
             } else if (msg) {
                 const handler = this['_on' + msg]


### PR DESCRIPTION
I added the code needed for my [issue](https://github.com/seeekr/ddp-client/issues/1)